### PR TITLE
Add cocktail recipe from amazon products

### DIFF
--- a/api/lib/tasks/import_data_from_csv.rake
+++ b/api/lib/tasks/import_data_from_csv.rake
@@ -9,8 +9,12 @@ namespace :import_data_from_csv do
     
     models.each do |model|
       p "Start: #{model} import"
-      array_of_hash = CSV.read(OUTPUT_DIR + "#{model.underscore}.csv", headers: true).map(&:to_hash)
-      eval("#{model}.insert_all!(array_of_hash)")
+      rows = CSV.read(OUTPUT_DIR + "#{model.underscore}.csv", headers: true)
+      rows.each_slice(1000) do |sliced_rows|
+        array_of_hash = sliced_rows.map(&:to_hash)
+        eval("#{model}.insert_all!(array_of_hash)")
+        ActiveRecord::Base.connection.execute("SELECT setval('#{model.underscore.pluralize}_id_seq', coalesce((SELECT MAX(id)+1 FROM #{model.underscore.pluralize}), 1), false)")
+      end
       p "End: #{model} import"
       p ''
     end

--- a/api/lib/tasks/tmp.rake
+++ b/api/lib/tasks/tmp.rake
@@ -11,13 +11,16 @@ namespace :tmp do
   desc 'base_ingredientから大量のアマゾン商品を見つけてきてそれをconcrete_ingredientに登録するタスク'
   task import_concrete_ingredients_from_amazon_products_by_base_ingredient_name: :environment do
     client = Paapi::Client.new
-    BaseIngredient.includes(:concrete_ingredients).all.each_with_index do |bi, i|
-      next if i < 365
+    BaseIngredient.includes(:concrete_ingredients, :category).all.each_with_index do |bi, i|
       p i, bi.name
+      # next if i < 524
 
-      response = client.search_items(keywords: bi.name, BrowseNodeId: '57240051', Local: 'ja_JP', SortBy: 'Featured', Resources: ['BrowseNodeInfo.BrowseNodes', 'Images.Primary.Medium', 'ItemInfo.Title'])
+      category = bi.category
+      next if category.nil?
+
+      response = client.search_items(keywords: bi.name, BrowseNodeId: category.amazon_browse_node_id.to_s, Local: 'ja_JP', SortBy: 'Featured', Resources: ['BrowseNodeInfo.BrowseNodes', 'Images.Primary.Medium', 'ItemInfo.Title'])
+      raise "#{response.http_response}" if response.http_response.code == 429
       searched_products = response.items
-      p searched_products
 
       searched_products.each do |asp|
         p asp


### PR DESCRIPTION
- amazonの商品検索rakeタスクの実装
- csvからデータをインポートしたときにidがインクリメントされていないのでその修正。