### PR TITLE
作れるカクテル一覧画面のMUI移行

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,9 +4,9 @@ RUN apt-get update -qq && apt-get install -qq -y \
   nodejs postgresql-client libpq-dev build-essential
 
 # yarn install
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install yarn
+# RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+# RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+# RUN apt-get update && apt-get install yarn
 
 RUN mkdir /myapp
 

--- a/frontend/src/components/CocktailImg.tsx
+++ b/frontend/src/components/CocktailImg.tsx
@@ -1,25 +1,25 @@
 type CocktailImgProps = {
   recipe: any;
+  width: number;
+  height: number | "";
 };
 
 type DrinkMethod = 'Build' | 'Shake' | 'Blend' | 'Stir';
 
-const CocktailImg: React.VFC<CocktailImgProps> = ({ recipe }) => {
+export const CocktailImg: React.VFC<CocktailImgProps> = ({ recipe, width, height }) => {
   const drinkMethod: DrinkMethod = recipe.drnkmethod;
 
   return (
     <>
       {drinkMethod === 'Build' ? (
-        <img src="/build.png" width={49} height={177} alt="ビルド" />
+        <img src="/build.png" width={width} height={height} alt="ビルド" />
       ) : drinkMethod === 'Shake' ? (
-        <img src="/shake.png" width={49} height={177} alt="シェイク" />
+        <img src="/shake.png" width={width} height={height} alt="シェイク" />
       ) : drinkMethod === 'Blend' ? (
-        <img src="/blend.png" width={49} height={177} alt="ブレンド" />
+        <img src="/blend.png" width={width} height={height} alt="ブレンド" />
       ) : (
-        <img src="/stir.png" width={49} height={177} alt="ステア" />
+        <img src="/stir.png" width={width} height={height} alt="ステア" />
       )}
     </>
   );
 };
-
-export default CocktailImg;

--- a/frontend/src/components/cocktailCard.tsx
+++ b/frontend/src/components/cocktailCard.tsx
@@ -2,7 +2,7 @@ import { Card, Grid } from '@mui/material';
 import Link from 'next/link';
 import type { VFC } from 'react';
 
-import CocktailImg from './CocktailImg';
+import {CocktailImg }from './CocktailImg';
 
 type RecipeProps = {
   id: any;
@@ -26,14 +26,14 @@ export const CocktailCard: VFC<CocktailProps> = ({ cocktails }) => {
       {cocktails.map((cocktail, recipe) => {
         return (
           <Link href={`/cocktail-recipe/${cocktail.id}`} key={cocktail.id}>
-            <Card variant="outlined">
-            <Grid container spacing={1}>
+            <Card style={{padding:"0.5rem", margin:"0.25rem"}}>
+            <Grid container spacing={3} sx={{display:"flex", alignItems:"center"}}>
               <Grid item xs={3}>
-                <CocktailImg recipe={recipe} />
+                <CocktailImg recipe={recipe} width={50} height={50} />
               </Grid>
               <Grid item xs={9}>
-                <h1 className="py-2 font-bold text-left">{cocktail.name}</h1>
-                <h2 className="text-xs text-left text-blue-500">
+                <h1 style={{padding: "0.5em 0", fontWeight:"bold"}}>{cocktail.name}</h1>
+                <h2 style={{fontSize: "0.75rem", lineHeight: "1rem", color:'#2196f3'}}>
                   {'すぐ作れる！'}
                 </h2>
               </Grid>

--- a/frontend/src/components/cocktailCard.tsx
+++ b/frontend/src/components/cocktailCard.tsx
@@ -1,3 +1,4 @@
+import { Card, Grid } from '@mui/material';
 import Link from 'next/link';
 import type { VFC } from 'react';
 
@@ -25,16 +26,20 @@ export const CocktailCard: VFC<CocktailProps> = ({ cocktails }) => {
       {cocktails.map((cocktail, recipe) => {
         return (
           <Link href={`/cocktail-recipe/${cocktail.id}`} key={cocktail.id}>
-            <div className="box-content flex p-2 w-auto h-20 border-b-2 border-barGray-1">
-              <CocktailImg recipe={recipe} />
-              <div className="m-2 w-56">
+            <Card variant="outlined">
+            <Grid container spacing={1}>
+              <Grid item xs={3}>
+                <CocktailImg recipe={recipe} />
+              </Grid>
+              <Grid item xs={9}>
                 <h1 className="py-2 font-bold text-left">{cocktail.name}</h1>
                 <h2 className="text-xs text-left text-blue-500">
                   {'すぐ作れる！'}
                 </h2>
-              </div>
-              <div className="px-2 my-auto h-16 text-xl">{'>'}</div>
-            </div>
+              </Grid>
+            </Grid>
+            </Card>
+           
           </Link>
         );
       })}

--- a/frontend/src/components/cocktailCard.tsx
+++ b/frontend/src/components/cocktailCard.tsx
@@ -1,25 +1,32 @@
 import Link from 'next/link';
-import { useRouter } from 'next/router';
 import type { VFC } from 'react';
-import { useGetRecipe } from 'src/utils/hooks/useGetRecipe';
+
 import CocktailImg from './CocktailImg';
+
+type RecipeProps = {
+  id: any;
+  name: any;
+  strength: any;
+  explanation: any;
+  drinkMethod: any;
+  glassType: any;
+  ingredients: any;
+}
 
 type CocktailProps = {
   cocktails: any[];
+  recipe: RecipeProps;
 };
 
-export const CocktailCards: VFC<CocktailProps> = ({ cocktails }) => {
-  const router = useRouter();
-  const cocktailId = Number(router?.query.id);
-  const { recipe } = useGetRecipe(cocktailId);
+
+export const CocktailCard: VFC<CocktailProps> = ({ cocktails }) => {
   return (
     <>
-      {cocktails.map((cocktail) => {
+      {cocktails.map((cocktail, recipe) => {
         return (
           <Link href={`/cocktail-recipe/${cocktail.id}`} key={cocktail.id}>
             <div className="box-content flex p-2 w-auto h-20 border-b-2 border-barGray-1">
               <CocktailImg recipe={recipe} />
-              <div className="m-2 w-16 h-16 bg-gray-300 rounded-lg"></div>
               <div className="m-2 w-56">
                 <h1 className="py-2 font-bold text-left">{cocktail.name}</h1>
                 <h2 className="text-xs text-left text-blue-500">

--- a/frontend/src/components/cocktailCard.tsx
+++ b/frontend/src/components/cocktailCard.tsx
@@ -1,8 +1,8 @@
-import { Card, Grid } from '@mui/material';
-import Link from 'next/link';
-import type { VFC } from 'react';
+import { Card, Grid } from "@mui/material";
+import Link from "next/link";
+import type { VFC } from "react";
 
-import {CocktailImg }from './CocktailImg';
+import { CocktailImg } from "./CocktailImg";
 
 type RecipeProps = {
   id: any;
@@ -12,13 +12,12 @@ type RecipeProps = {
   drinkMethod: any;
   glassType: any;
   ingredients: any;
-}
+};
 
 type CocktailProps = {
   cocktails: any[];
   recipe: RecipeProps;
 };
-
 
 export const CocktailCard: VFC<CocktailProps> = ({ cocktails }) => {
   return (
@@ -26,20 +25,29 @@ export const CocktailCard: VFC<CocktailProps> = ({ cocktails }) => {
       {cocktails.map((cocktail, recipe) => {
         return (
           <Link href={`/cocktail-recipe/${cocktail.id}`} key={cocktail.id}>
-            <Card style={{padding:"0.5rem", margin:"0.25rem"}}>
-            <Grid container spacing={3} sx={{display:"flex", alignItems:"center"}}>
-              <Grid item xs={3}>
-                <CocktailImg recipe={recipe} width={50} height={50} />
+            <Card style={{ padding: "0.5rem", margin: "0.25rem" }}>
+              <Grid
+                container
+                spacing={3}
+                sx={{ display: "flex", alignItems: "center" }}>
+                <Grid item xs={3}>
+                  <CocktailImg recipe={recipe} width={50} height={50} />
+                </Grid>
+                <Grid item xs={9}>
+                  <h1 style={{ padding: "0.5em 0", fontWeight: "bold" }}>
+                    {cocktail.name}
+                  </h1>
+                  <h2
+                    style={{
+                      fontSize: "0.75rem",
+                      lineHeight: "1rem",
+                      color: "#2196f3",
+                    }}>
+                    {"すぐ作れる！"}
+                  </h2>
+                </Grid>
               </Grid>
-              <Grid item xs={9}>
-                <h1 style={{padding: "0.5em 0", fontWeight:"bold"}}>{cocktail.name}</h1>
-                <h2 style={{fontSize: "0.75rem", lineHeight: "1rem", color:'#2196f3'}}>
-                  {'すぐ作れる！'}
-                </h2>
-              </Grid>
-            </Grid>
             </Card>
-           
           </Link>
         );
       })}

--- a/frontend/src/pages/blog/index.page.tsx
+++ b/frontend/src/pages/blog/index.page.tsx
@@ -4,9 +4,7 @@ import matter from 'gray-matter';
 import type { GetStaticProps } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useContext, useEffect } from 'react';
 import { NonFooterLayout } from 'src/components/Layout/nonFooter';
-import { Context } from 'src/utils/contexts/provider';
 import { useGetUser } from 'src/utils/hooks/useGetUser';
 
 export const getStaticProps: GetStaticProps = async () => {
@@ -37,7 +35,13 @@ export const getStaticProps: GetStaticProps = async () => {
 };
 
 const BlogList: React.VFC = (props: any) => {
+  const router = useRouter()
   const { getUserFn } = useGetUser();
+
+  const handleClick = () => {
+    router.push("/sakagura")
+    getUserFn()
+  }
 
   return (
     <NonFooterLayout>
@@ -49,7 +53,7 @@ const BlogList: React.VFC = (props: any) => {
             作れるカクテルを見つけよう
           </h1>
 
-          <Button variant="contained" onClick={getUserFn} color="primary">
+          <Button variant="contained" onClick={handleClick} color="primary">
             お家barに行く
           </Button>
         </div>

--- a/frontend/src/pages/cocktail-recipe/[id].page.tsx
+++ b/frontend/src/pages/cocktail-recipe/[id].page.tsx
@@ -1,12 +1,12 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useContext } from 'react';
+import {CocktailImg} from 'src/components/CocktailImg';
 import { ContentWraper } from 'src/components/ContentWrapper';
 import { Layout } from 'src/components/Layout';
-import { useGetRecipe } from 'src/utils/hooks/useGetRecipe';
-import { useContext } from 'react';
 import { Context } from 'src/utils/contexts/provider';
 import { pushHome } from 'src/utils/hooks/pushHome';
-import CocktailImg from 'src/components/CocktailImg';
+import { useGetRecipe } from 'src/utils/hooks/useGetRecipe';
 
 const ToCocktailsLink: React.VFC = () => {
   return (
@@ -36,7 +36,7 @@ export const CocktailRecipe: React.VFC = () => {
           ) : (
             <>
               <div className="flex p-2 m-4">
-                <CocktailImg recipe={recipe} />
+                <CocktailImg recipe={recipe} width={80} height={80}/>
                 <p className="place-self-center py-4 text-lg font-bold">
                   {recipe.name}
                 </p>

--- a/frontend/src/pages/cocktails/index.page.tsx
+++ b/frontend/src/pages/cocktails/index.page.tsx
@@ -1,12 +1,12 @@
 //mochikun用
-import { useRouter } from 'next/router';
-import type { VFC } from 'react';
-import { useEffect } from 'react';
-import { CocktailCard } from 'src/components/CocktailCard';
-import { Layout } from 'src/components/Layout';
-import { ToRegisterModal } from 'src/components/ToRegisterModal';
-import { useGetCocktails } from 'src/utils/hooks/useGetCocktails';
-import { useGetRecipe } from 'src/utils/hooks/useGetRecipe';
+import { useRouter } from "next/router";
+import type { VFC } from "react";
+import { useEffect } from "react";
+import { CocktailCard } from "src/components/CocktailCard";
+import { Layout } from "src/components/Layout";
+import { ToRegisterModal } from "src/components/ToRegisterModal";
+import { useGetCocktails } from "src/utils/hooks/useGetCocktails";
+import { useGetRecipe } from "src/utils/hooks/useGetRecipe";
 
 const CocktailPage: VFC = () => {
   const { cocktails, loading, error, getCocktailsFn } = useGetCocktails();
@@ -21,12 +21,12 @@ const CocktailPage: VFC = () => {
 
   return (
     <Layout>
-      {loading && <p>ローディング中です</p>}
-      {cocktails?.length == 0 && <ToRegisterModal name="作成可能なカクテル" />}
+      {loading && <p style={{ margin: "1rem" }}>ローディング中です</p>}
+      {cocktails?.length == 0 && <ToRegisterModal name='作成可能なカクテル' />}
       {error && <p>エラーが発生しました</p>}
       {cocktails && (
-        <div className="container">
-          <CocktailCard cocktails={cocktails} recipe={recipe}/>
+        <div className='container'>
+          <CocktailCard cocktails={cocktails} recipe={recipe} />
         </div>
       )}
     </Layout>

--- a/frontend/src/pages/cocktails/index.page.tsx
+++ b/frontend/src/pages/cocktails/index.page.tsx
@@ -1,11 +1,12 @@
 //mochikun用
+import { useRouter } from 'next/router';
 import type { VFC } from 'react';
-import { useEffect, useContext } from 'react';
-import { Context } from 'src/utils/contexts/provider';
-import { CocktailCards } from 'src/components/cocktailCard';
+import { useEffect } from 'react';
+import { CocktailCard } from 'src/components/CocktailCard';
 import { Layout } from 'src/components/Layout';
 import { ToRegisterModal } from 'src/components/ToRegisterModal';
 import { useGetCocktails } from 'src/utils/hooks/useGetCocktails';
+import { useGetRecipe } from 'src/utils/hooks/useGetRecipe';
 
 const CocktailPage: VFC = () => {
   const { cocktails, loading, error, getCocktailsFn } = useGetCocktails();
@@ -14,6 +15,10 @@ const CocktailPage: VFC = () => {
     getCocktailsFn();
   }, [getCocktailsFn]);
 
+  const router = useRouter();
+  const cocktailId = Number(router?.query.id);
+  const { recipe } = useGetRecipe(cocktailId);
+
   return (
     <Layout>
       {loading && <p>ローディング中です</p>}
@@ -21,7 +26,7 @@ const CocktailPage: VFC = () => {
       {error && <p>エラーが発生しました</p>}
       {cocktails && (
         <div className="container">
-          <CocktailCards cocktails={cocktails} />
+          <CocktailCard cocktails={cocktails} recipe={recipe}/>
         </div>
       )}
     </Layout>

--- a/frontend/src/utils/hooks/useGetCocktails.ts
+++ b/frontend/src/utils/hooks/useGetCocktails.ts
@@ -22,6 +22,5 @@ export const useGetCocktails = () => {
       explanation: cocktail?.cookExplanation,
     };
   });
-
   return { cocktails, loading, error, getCocktailsFn };
 };


### PR DESCRIPTION
fix: #{issue番号}

# プルリク出す前にチェック！
- [x] 何の修正かわかるタイトルを付けましたか？
- [x] 必要手順があれば書くこと（`yarn install`とか`rails db:migrate`とか）
- [x] 気になることがあれば書くとこ(このページのここ実装臭くない？とか)
- フロントエンドの修正がある場合
  - [x] 機能動画(画像)を添付しましたか？

# 機能動画(画像or動画)
- 
<img width="335" alt="スクリーンショット 2022-07-09 9 46 03" src="https://user-images.githubusercontent.com/84134634/178085566-a32a3070-f557-4001-82fa-f695aac5c7d0.png">


# 申し送り事項
レシピ情報をカードではなくページで取得するようにしました

## 必要手順
特になし

## その他、気になる点
ローディング中の表示をスケルトンにしてもいいかもしれない
